### PR TITLE
Removed Strict ROS Melodic Dependency In 'compile_ros_workspace.sh' 

### DIFF
--- a/compile_ros_workspace.sh
+++ b/compile_ros_workspace.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Use the system ROS version, or melodic if there is no system version
+ROSDISTRO="${ROSDISTRO:-melodic}"
+
 PACKAGES="roscpp rospy"
 
 rm -rf bundle_ws
@@ -12,7 +15,6 @@ rosinstall_generator \
     --deps \
     --tar \
     --flat \
-    --rosdistro melodic \
     $PACKAGES > ws.rosinstall
 wstool init -j8 src ws.rosinstall
 


### PR DESCRIPTION
I believe the `--rosdistro melodic` flag can safely be removed and allow this repo to still support ROS Kinetic (even if unofficially). With this removed everything appears to work with Kinetic. 

P.S. Thanks for the great project! This was exactly what I needed.