### PR TITLE
Remove unnecessary escaping to avoid bazel flag

### DIFF
--- a/bazel/path_utils.bzl
+++ b/bazel/path_utils.bzl
@@ -21,7 +21,7 @@ def join_paths(*args):
     """Join paths without duplicating separators.
     This is roughly equivalent to Python's `os.path.join`.
     Args:
-        \*args (:obj:`list` of :obj:`str`): Path components to be joined.
+        *args (:obj:`list` of :obj:`str`): Path components to be joined.
     Returns:
         :obj:`str`: The concatenation of the input path components.
     """


### PR DESCRIPTION
Otherwise, need to use `--incompatible_restrict_string_escapes=false` to avoid this on latest bazel